### PR TITLE
[TAS-35] TextField 컴포넌트 구현 및 Button 컴포넌트 보완

### DIFF
--- a/.ondevice/storybook.requires.js
+++ b/.ondevice/storybook.requires.js
@@ -6,37 +6,37 @@ import {
   addParameters,
   addArgsEnhancer,
   clearDecorators,
-} from '@storybook/react-native';
-
-import '@storybook/addon-ondevice-notes/register';
-import '@storybook/addon-ondevice-controls/register';
-import '@storybook/addon-ondevice-backgrounds/register';
-import '@storybook/addon-ondevice-actions/register';
-
-import {argsEnhancers} from '@storybook/addon-actions/dist/modern/preset/addArgs';
-
-import {decorators, parameters} from './preview';
+} from "@storybook/react-native";
 
 global.STORIES = [
   {
-    titlePrefix: '',
-    directory: './src',
-    files: '**/*.stories.?(ts|tsx|js|jsx)',
+    titlePrefix: "",
+    directory: "./src",
+    files: "**/*.stories.?(ts|tsx|js|jsx)",
     importPathMatcher:
-      '^\\.[\\\\/](?:src(?:[\\\\/](?!\\.)(?:(?:(?!(?:^|[\\\\/])\\.).)*?)[\\\\/]|[\\\\/]|$)(?!\\.)(?=.)[^\\\\/]*?\\.stories\\.(?:ts|tsx|js|jsx)?)$',
+      "^\\.[\\\\/](?:src(?:\\/(?!\\.)(?:(?:(?!(?:^|\\/)\\.).)*?)\\/|\\/|$)(?!\\.)(?=.)[^/]*?\\.stories\\.(?:ts|tsx|js|jsx)?)$",
   },
 ];
+
+import "@storybook/addon-ondevice-notes/register";
+import "@storybook/addon-ondevice-controls/register";
+import "@storybook/addon-ondevice-backgrounds/register";
+import "@storybook/addon-ondevice-actions/register";
+
+import { argsEnhancers } from "@storybook/addon-actions/dist/modern/preset/addArgs";
+
+import { decorators, parameters } from "./preview";
 
 if (decorators) {
   if (__DEV__) {
     // stops the warning from showing on every HMR
-    require('react-native').LogBox.ignoreLogs([
-      '`clearDecorators` is deprecated and will be removed in Storybook 7.0',
+    require("react-native").LogBox.ignoreLogs([
+      "`clearDecorators` is deprecated and will be removed in Storybook 7.0",
     ]);
   }
   // workaround for global decorators getting infinitely applied on HMR, see https://github.com/storybookjs/react-native/issues/185
   clearDecorators();
-  decorators.forEach(decorator => addDecorator(decorator));
+  decorators.forEach((decorator) => addDecorator(decorator));
 }
 
 if (parameters) {
@@ -44,12 +44,13 @@ if (parameters) {
 }
 
 try {
-  argsEnhancers.forEach(enhancer => addArgsEnhancer(enhancer));
+  argsEnhancers.forEach((enhancer) => addArgsEnhancer(enhancer));
 } catch {}
 
 const getStories = () => {
   return {
-    './src/components/Button/Button.stories': require('../src/components/Button/Button.stories'),
+    "./src/components/Button/Button.stories.tsx": require("../src/components/Button/Button.stories.tsx"),
+    "./src/components/TextField/TextField.stories.tsx": require("../src/components/TextField/TextField.stories.tsx"),
   };
 };
 

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -17,7 +17,6 @@ export const FullWidthPrimary = Template.bind({});
 FullWidthPrimary.args = {
   variant: 'primary',
   fullWidth: true,
-  isActive: true,
   children: '내용',
 };
 
@@ -25,7 +24,7 @@ export const DisabledPrimary = Template.bind({});
 DisabledPrimary.args = {
   variant: 'primary',
   fullWidth: true,
-  isActive: false,
+  disabled: true,
   children: '내용',
 };
 
@@ -33,7 +32,6 @@ export const Primary = Template.bind({});
 Primary.args = {
   variant: 'primary',
   fullWidth: false,
-  isActive: true,
   children: '내용',
 };
 
@@ -41,6 +39,5 @@ export const Secondary = Template.bind({});
 Secondary.args = {
   variant: 'secondary',
   fullWidth: false,
-  isActive: true,
   children: '내용',
 };

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,5 +1,9 @@
 import Typography from 'components/Typography';
-import {StyleSheet, TouchableOpacity} from 'react-native';
+import {
+  StyleSheet,
+  TouchableOpacity,
+  TouchableOpacityProps,
+} from 'react-native';
 import {theme} from 'styles';
 
 const TEXT_COLOR = {
@@ -28,39 +32,31 @@ const BACKGROUND_COLOR = {
  * @param variant 버튼 종류: 'primary' | 'secondary'
  * @param fullWidth 버튼 크기: 고정된 크기 / 화면에 꽉 차게
  * @param isActive active 여부
- * @param onPress 버튼 클릭 시 발생할 함수
  * @param children 버튼 텍스트
  */
 type ButtonProps = {
   variant?: 'primary' | 'secondary';
   fullWidth?: boolean;
-  isActive?: boolean;
-  onPress?: () => void;
   children: string;
-};
+} & TouchableOpacityProps;
 
 export default function Button({
   variant = 'primary',
   fullWidth = true,
-  isActive = true,
-  onPress,
   children,
+  ...props
 }: ButtonProps) {
-  const getStyle = () => {
-    const activeVariant = isActive ? 'normal' : 'disabled';
-    const backgroundColor =
-      theme.palette[BACKGROUND_COLOR[activeVariant][variant]];
-    const textColor = TEXT_COLOR[activeVariant][variant];
-    const width = fullWidth ? 335 : 163.5;
+  const activeVariant = props.disabled ? 'disabled' : 'normal';
 
-    return {backgroundColor, textColor, width};
+  const {backgroundColor, textColor, width} = {
+    backgroundColor: theme.palette[BACKGROUND_COLOR[activeVariant][variant]],
+    textColor: TEXT_COLOR[activeVariant][variant],
+    width: fullWidth ? '100%' : '50%',
   };
-
-  const {backgroundColor, textColor, width} = getStyle();
 
   return (
     <TouchableOpacity
-      onPress={() => onPress?.()}
+      {...props}
       style={{
         ...buttonStyles.button,
         backgroundColor,
@@ -80,5 +76,6 @@ const buttonStyles = StyleSheet.create({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
+    maxWidth: '100%',
   },
 });

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -63,8 +63,8 @@ export default function Button({
       onPress={() => onPress?.()}
       style={{
         ...buttonStyles.button,
-        backgroundColor: backgroundColor,
-        width: width,
+        backgroundColor,
+        width,
       }}>
       <Typography type={'Body1Semibold'} color={textColor}>
         {children}

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -31,7 +31,6 @@ const BACKGROUND_COLOR = {
 /**
  * @param variant 버튼 종류: 'primary' | 'secondary'
  * @param fullWidth 버튼 크기: 고정된 크기 / 화면에 꽉 차게
- * @param isActive active 여부
  * @param children 버튼 텍스트
  */
 type ButtonProps = {

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -1,0 +1,23 @@
+import {ComponentStory} from '@storybook/react';
+import TextField from 'components/TextField';
+
+const meta = {
+  title: 'component/TextField',
+  component: TextField,
+};
+
+export default meta;
+
+type Story = ComponentStory<typeof TextField>;
+
+const Template: Story = args => <TextField {...args} />;
+
+export const DefaultStatus = Template.bind({});
+DefaultStatus.args = {
+  value: '',
+};
+
+export const FilledStatus = Template.bind({});
+FilledStatus.args = {
+  value: '입력 완료',
+};

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -1,5 +1,5 @@
 import Icon from 'components/Icon';
-import React from 'react';
+import React, {useState} from 'react';
 import {
   StyleSheet,
   TextInput,
@@ -19,20 +19,28 @@ export default function TextField({
   onChangeText,
   ...props
 }: TextFieldProps) {
-  const clearInput = () => {
-    onChangeText('');
-  };
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+
+  const handleFocus = () => setIsFocused(true);
+  const handleBlur = () => setIsFocused(false);
+
+  const clearInput = () => onChangeText('');
 
   return (
     <View
-      style={{
-        ...styles.container,
-        borderBottomColor: theme.palette[value ? 'primary' : 'gray3'],
-      }}>
+      style={[
+        styles.container,
+        {
+          borderBottomColor:
+            theme.palette[isFocused || value ? 'primary' : 'gray3'],
+        },
+      ]}>
       <TextInput
         value={value}
         onChangeText={onChangeText}
         placeholder={props.placeholder ?? '내용을 입력해주세요.'}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
         style={styles.text}
       />
       {value !== '' && (
@@ -57,6 +65,7 @@ const styles = StyleSheet.create({
   },
   text: {
     ...theme.typography.Title1Semibold1,
+    placeholderTextColor: theme.palette.gray3,
     maxWidth: '93%',
   },
   clearButton: {},

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -9,10 +9,15 @@ import {
 } from 'react-native';
 import {theme} from 'styles';
 
+/**
+ * @param value 텍스트 필드에 표시될 값
+ * @param onChangeText 값이 변경될 때 호출. 변경된 텍스트가 매개변수로 전달
+ * @param ...props - react native TextInputProps
+ */
 type TextFieldProps = {
   value: string;
   onChangeText: (text: string) => void;
-} & TextInputProps;
+} & Omit<TextInputProps, 'value' | 'onChangeText'>;
 
 export default function TextField({
   value,

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -1,0 +1,63 @@
+import Icon from 'components/Icon';
+import React from 'react';
+import {
+  StyleSheet,
+  TextInput,
+  TextInputProps,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {theme} from 'styles';
+
+type TextFieldProps = {
+  value: string;
+  onChangeText: (text: string) => void;
+} & TextInputProps;
+
+export default function TextField({
+  value,
+  onChangeText,
+  ...props
+}: TextFieldProps) {
+  const clearInput = () => {
+    onChangeText('');
+  };
+
+  return (
+    <View
+      style={{
+        ...styles.container,
+        borderBottomColor: theme.palette[value ? 'primary' : 'gray3'],
+      }}>
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={props.placeholder ?? '내용을 입력해주세요.'}
+        style={styles.text}
+      />
+      {value !== '' && (
+        <TouchableOpacity onPress={clearInput} style={styles.clearButton}>
+          <Icon name="XCircle" color={theme.palette.gray3} />
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    borderBottomWidth: 1,
+    borderBottomColor: theme.palette.primary,
+    justifyContent: 'space-between',
+    gap: 10,
+    alignItems: 'center',
+    paddingVertical: 11,
+    paddingHorizontal: 16,
+  },
+  text: {
+    ...theme.typography.Title1Semibold1,
+    maxWidth: '93%',
+  },
+  clearButton: {},
+});

--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -15,11 +15,11 @@ export default function Typography({
   return (
     <Text
       {...props}
-      style={Object.assign(
+      style={[
+        props.style,
         {color: theme.palette[color]},
-        props.style ?? {},
         theme.typography[type],
-      )}>
+      ]}>
       {props.children}
     </Text>
   );


### PR DESCRIPTION
## Describe your changes
- TextField 컴포넌트 구현
- 스토리 작성
- Button 컴포넌트에 TouchableOpacityProps 추가
- Button full width props에 '100%'로 변경

## To Reviewers
스토리북 처음 써보는데 좋네요!
1. TextField
- default
<img width="508" alt="스크린샷 2024-01-05 오후 11 10 34" src="https://github.com/Central-MakeUs/Easybud-Client/assets/80194238/a925ffee-2395-49e9-b3ae-3d2b917ae665">

- filled
<img width="504" alt="스크린샷 2024-01-05 오후 11 11 11" src="https://github.com/Central-MakeUs/Easybud-Client/assets/80194238/03131bf9-5135-46f3-b761-cc5e74760d33">

- focus(텍스트 테두리는 storybook 자체적으로 적용된 것이니 무시해주세요)
<img width="510" alt="스크린샷 2024-01-05 오후 11 11 43" src="https://github.com/Central-MakeUs/Easybud-Client/assets/80194238/c33d0cd2-fca4-456c-9877-cf42c3ddee7b">

2. Button
- disabled fullWidth
<img width="507" alt="스크린샷 2024-01-05 오후 11 13 04" src="https://github.com/Central-MakeUs/Easybud-Client/assets/80194238/daf72ba5-334f-4121-9052-93e9fa3400b1">

- etc
<img width="511" alt="스크린샷 2024-01-05 오후 11 13 39" src="https://github.com/Central-MakeUs/Easybud-Client/assets/80194238/67c55ec9-d194-4d5f-b2e3-0f2287ef13b9">



