### PR TITLE
[TAS-46] 로그인 상태 관리 방식 보완

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,13 +1,10 @@
 import Navigator from 'containers/NavigatorContainer';
 import AppSetupWrapper from 'containers/AppSetupContainer';
-import {SafeAreaProvider} from 'react-native-safe-area-context';
 
 const App = () => {
   return (
     <AppSetupWrapper>
-      <SafeAreaProvider>
-        <Navigator />
-      </SafeAreaProvider>
+      <Navigator />
     </AppSetupWrapper>
   );
 };

--- a/src/containers/AppSetupContainer.tsx
+++ b/src/containers/AppSetupContainer.tsx
@@ -1,13 +1,16 @@
 import React, {ReactNode} from 'react';
 import RecoilContainer from 'containers/RecoilContainer';
 import ReactQueryContainer from 'containers/ReactQueryContainer';
+import {SafeAreaProvider} from 'react-native-safe-area-context';
 
 type AppSetupContainerProps = {children: ReactNode};
 
 export default function AppSetupContainer({children}: AppSetupContainerProps) {
   return (
     <RecoilContainer>
-      <ReactQueryContainer>{children}</ReactQueryContainer>
+      <ReactQueryContainer>
+        <SafeAreaProvider>{children}</SafeAreaProvider>
+      </ReactQueryContainer>
     </RecoilContainer>
   );
 }

--- a/src/containers/NavigatorContainer.tsx
+++ b/src/containers/NavigatorContainer.tsx
@@ -1,6 +1,5 @@
 import {DefaultTheme, NavigationContainer} from '@react-navigation/native';
 import StackNavigator from 'navigators/StackNavigator';
-import {useState} from 'react';
 import {lightPalette} from 'styles';
 
 const theme = {
@@ -9,12 +8,9 @@ const theme = {
 };
 
 const NavigatorContainer = () => {
-  // TODO 로그인 처리 후 상태 변경 필요
-  const [isLoggedIn, _] = useState(false);
-
   return (
     <NavigationContainer theme={theme}>
-      <StackNavigator isLoggedIn={isLoggedIn} />
+      <StackNavigator />
     </NavigationContainer>
   );
 };

--- a/src/hooks/useAppInitial.tsx
+++ b/src/hooks/useAppInitial.tsx
@@ -1,0 +1,18 @@
+import useAuthStorage from 'hooks/useAuthStorage';
+
+/** 프로젝트 최상단에서 user 데이터 불러오기  */
+export default function useAppInitial() {
+  // Todo: get user info using token
+  const {token} = useAuthStorage();
+  token;
+
+  // Todo: check authenticated
+  const isAuthenticated = true;
+  // Todo: navigate login page
+  const isVerifyTokenError = false;
+  isVerifyTokenError;
+
+  const isVerifyTokenLoading = false;
+
+  return {isAuthenticated, isVerifyTokenLoading};
+}

--- a/src/hooks/useAuthStorage.tsx
+++ b/src/hooks/useAuthStorage.tsx
@@ -1,0 +1,28 @@
+import {tokenState} from 'libs/recoil/states/token';
+import {useCallback} from 'react';
+import {useRecoilState} from 'recoil';
+
+/** auth token manager */
+export default function useAuthStorage() {
+  const [token, setToken] = useRecoilState(tokenState);
+
+  const isEmptyToken = token?.length === 0;
+
+  function setAuthData({accessToken}: {accessToken: string | null}) {
+    setToken(accessToken);
+  }
+
+  const clear = useCallback(() => {
+    if (isEmptyToken) {
+      return;
+    }
+
+    setToken(null);
+  }, [isEmptyToken, setToken]);
+
+  return {
+    token,
+    setAuthData,
+    clear,
+  };
+}

--- a/src/hooks/useInitialData.tsx
+++ b/src/hooks/useInitialData.tsx
@@ -1,7 +1,7 @@
 import useAuthStorage from 'hooks/useAuthStorage';
 
 /** 프로젝트 최상단에서 user 데이터 불러오기  */
-export default function useAppInitial() {
+export default function useInitialData() {
   // Todo: get user info using token
   const {token} = useAuthStorage();
   token;

--- a/src/libs/recoil/keys.ts
+++ b/src/libs/recoil/keys.ts
@@ -1,0 +1,7 @@
+export const enum RecoilStateKeys {
+  /** Token */
+  Token = 'token',
+
+  /** Funnel Step */
+  FunnelStep = 'funnel_step',
+}

--- a/src/libs/recoil/states/steps.ts
+++ b/src/libs/recoil/states/steps.ts
@@ -1,5 +1,6 @@
 import {atom} from 'recoil';
 import {Steps} from 'navigators/constants/steps';
+import {RecoilStateKeys} from 'libs/recoil/keys';
 
 type StepsType = {
   currentStep: keyof typeof Steps;
@@ -9,7 +10,7 @@ const initialState: StepsType = {
   currentStep: 'Step1',
 };
 
-export const stepsState = atom<StepsType>({
-  key: 'steps',
+export const funnelStepsState = atom<StepsType>({
+  key: RecoilStateKeys.FunnelStep,
   default: initialState,
 });

--- a/src/libs/recoil/states/token.ts
+++ b/src/libs/recoil/states/token.ts
@@ -1,0 +1,8 @@
+import {atom} from 'recoil';
+import {RecoilStateKeys} from 'libs/recoil/keys';
+
+// Todo: save with async storage
+export const tokenState = atom<string | null>({
+  key: RecoilStateKeys.Token,
+  default: null,
+});

--- a/src/navigators/StackNavigator.tsx
+++ b/src/navigators/StackNavigator.tsx
@@ -1,5 +1,5 @@
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
-import useAppInitial from 'hooks/useAppInitial';
+import useInitialData from 'hooks/useInitialData';
 import TabNavigator from 'navigators/TabNavigator';
 import {StackMenu} from 'navigators/constants/menu';
 import {StackParamList} from 'navigators/types';
@@ -13,7 +13,7 @@ const screenOptions = {
 };
 
 export default function StackNavigator() {
-  const {isAuthenticated, isVerifyTokenLoading} = useAppInitial();
+  const {isAuthenticated, isVerifyTokenLoading} = useInitialData();
 
   if (isVerifyTokenLoading) {
     return null; // Todo: global loading

--- a/src/navigators/StackNavigator.tsx
+++ b/src/navigators/StackNavigator.tsx
@@ -15,15 +15,17 @@ const screenOptions = {
 export default function StackNavigator() {
   const {isAuthenticated, isVerifyTokenLoading} = useInitialData();
 
+  const initialRouteName = isAuthenticated
+    ? StackMenu.TabNavigator
+    : StackMenu.OnBoarding;
+
   if (isVerifyTokenLoading) {
     return null; // Todo: global loading
   }
 
   return (
     <Stack.Navigator
-      initialRouteName={
-        isAuthenticated ? StackMenu.TabNavigator : StackMenu.OnBoarding
-      }
+      initialRouteName={initialRouteName}
       screenOptions={screenOptions}>
       {isAuthenticated ? (
         <Stack.Screen name={StackMenu.TabNavigator} component={TabNavigator} />

--- a/src/navigators/StackNavigator.tsx
+++ b/src/navigators/StackNavigator.tsx
@@ -1,12 +1,9 @@
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
-import {useRecoilValue} from 'recoil';
-import {stepsState} from 'libs/recoil/steps';
+import useAppInitial from 'hooks/useAppInitial';
 import TabNavigator from 'navigators/TabNavigator';
 import {StackMenu} from 'navigators/constants/menu';
-import {stepInfoList, steps} from 'navigators/constants/steps';
 import {StackParamList} from 'navigators/types';
-import Funnel from 'components/@common/Funnel/Funnel';
-import Step from 'components/@common/Funnel/Step';
+import OnBoardingFunnel from 'screens/OnBoarding';
 
 const Stack = createNativeStackNavigator<StackParamList>();
 
@@ -15,31 +12,27 @@ const screenOptions = {
   headerShadowVisible: false,
 };
 
-type StackNavigatorProps = {
-  isLoggedIn: boolean;
-};
+export default function StackNavigator() {
+  const {isAuthenticated, isVerifyTokenLoading} = useAppInitial();
 
-export default function StackNavigator({isLoggedIn}: StackNavigatorProps) {
-  const {currentStep} = useRecoilValue(stepsState);
+  if (isVerifyTokenLoading) {
+    return null; // Todo: global loading
+  }
 
   return (
-    <Stack.Navigator screenOptions={screenOptions}>
-      <Stack.Screen
-        name={StackMenu.OnBoarding}
-        component={
-          isLoggedIn
-            ? TabNavigator
-            : () => (
-                <Funnel steps={steps} step={currentStep}>
-                  {stepInfoList.map(({name, component}) => (
-                    <Step key={name} name={name}>
-                      {component}
-                    </Step>
-                  ))}
-                </Funnel>
-              )
-        }
-      />
+    <Stack.Navigator
+      initialRouteName={
+        isAuthenticated ? StackMenu.TabNavigator : StackMenu.OnBoarding
+      }
+      screenOptions={screenOptions}>
+      {isAuthenticated ? (
+        <Stack.Screen name={StackMenu.TabNavigator} component={TabNavigator} />
+      ) : (
+        <Stack.Screen
+          name={StackMenu.OnBoarding}
+          component={OnBoardingFunnel}
+        />
+      )}
     </Stack.Navigator>
   );
 }

--- a/src/screens/OnBoarding/index.tsx
+++ b/src/screens/OnBoarding/index.tsx
@@ -1,0 +1,20 @@
+import Funnel from 'components/@common/Funnel/Funnel';
+import Step from 'components/@common/Funnel/Step';
+import {funnelStepsState} from 'libs/recoil/states/steps';
+import {stepInfoList, steps} from 'navigators/constants/steps';
+import React from 'react';
+import {useRecoilValue} from 'recoil';
+
+export default function OnBoardingFunnel() {
+  const {currentStep} = useRecoilValue(funnelStepsState);
+
+  return (
+    <Funnel steps={steps} step={currentStep}>
+      {stepInfoList.map(({name, component}) => (
+        <Step key={name} name={name}>
+          {component}
+        </Step>
+      ))}
+    </Funnel>
+  );
+}


### PR DESCRIPTION
## Describe your changes
- 기존 useState로 임시 구현해두었던 hook 사용해 관리하는 방식으로 변경

## To Reviewers
- 카카오 로그인 본격적으로 구현 전에 관련 세팅을 해둬야할 것 같아서 보완 작업 진행했습니다.
- 다음 태스크로 recoil - async storage 연동 기능 이어서 해보려 합니다. 
