### PR TITLE
[TAS-66] 텍스트 필드 현재 대차 및 금액 계산 로직 추가

### DIFF
--- a/src/components/@common/TextField/TextField.stories.tsx
+++ b/src/components/@common/TextField/TextField.stories.tsx
@@ -13,4 +13,6 @@ type Story = ComponentStory<typeof TextField>;
 const Template: Story = args => <TextField {...args} />;
 
 export const DefaultStatus = Template.bind({});
-DefaultStatus.args = {};
+DefaultStatus.args = {
+  defaultCurrentBalance: '-8500000',
+};

--- a/src/components/@common/TextField/index.tsx
+++ b/src/components/@common/TextField/index.tsx
@@ -48,8 +48,6 @@ export default function TextField({defaultValue, ...props}: TextFieldProps) {
         const parsedValue = parseNumberFromString(value).slice(0, -1);
 
         setValue(`${formatNumberToLocaleString(parsedValue)}원`);
-      } else {
-        setValue(`0원`);
       }
 
       e.preventDefault();

--- a/src/components/@common/TextField/index.tsx
+++ b/src/components/@common/TextField/index.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {
   NativeSyntheticEvent,
   StyleSheet,
@@ -16,10 +16,18 @@ import {
   parseNumberFromString,
 } from 'utils/formatValue';
 import Icon from 'components/@common/Icon';
+import Typography from 'components/@common/Typography';
 
-type TextFieldProps = TextInputProps;
+/**
+ * @param defaultCurrentBalance 현재 대차를 나타내는 텍스트
+ */
+type TextFieldProps = {defaultCurrentBalance?: string} & TextInputProps;
 
-export default function TextField({defaultValue, ...props}: TextFieldProps) {
+export default function TextField({
+  defaultValue,
+  defaultCurrentBalance,
+  ...props
+}: TextFieldProps) {
   const [value, setValue] = useState(formatValue(defaultValue) ?? '');
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const [height, setHeight] = useState(0);
@@ -54,40 +62,77 @@ export default function TextField({defaultValue, ...props}: TextFieldProps) {
     }
   };
 
+  const calculateCurrentBalance = () => {
+    const currentBalance = formatNumberToLocaleString(
+      String(
+        -parseNumberFromString(defaultCurrentBalance!) +
+          Number(parseNumberFromString(value)),
+      ),
+    );
+
+    return currentBalance;
+  };
+
+  const handlePressCurrentBalanceButton = () => {
+    setValue(
+      formatValue(
+        String(
+          -(
+            -parseNumberFromString(defaultCurrentBalance!) +
+            Number(parseNumberFromString(value))
+          ),
+        ),
+      ),
+    );
+  };
+
   return (
-    <View
-      style={[
-        styles.container,
-        {
-          borderBottomColor:
-            theme.palette[isFocused || value ? 'primary' : 'gray3'],
-        },
-      ]}>
-      <TextInput
-        value={value}
-        onChangeText={onChangeText}
-        placeholder={props.placeholder ?? '내용을 입력해주세요.'}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-        onKeyPress={handleKeyPress}
-        multiline={true}
-        underlineColorAndroid="transparent"
-        onContentSizeChange={handleInputHeight}
-        style={[styles.textInput, {height}]}
-      />
-      {value !== '' && (
-        <TouchableOpacity onPress={clearInput}>
-          <Icon name="XCircle" color={theme.palette.gray3} />
+    <>
+      <View
+        style={[
+          textFieldStyles.textFieldContainer,
+          {
+            borderBottomColor:
+              theme.palette[isFocused || value ? 'primary' : 'gray3'],
+          },
+        ]}>
+        <TextInput
+          value={value}
+          onChangeText={onChangeText}
+          placeholder={props.placeholder ?? '내용을 입력해주세요.'}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onKeyPress={handleKeyPress}
+          multiline={true}
+          underlineColorAndroid="transparent"
+          onContentSizeChange={handleInputHeight}
+          style={[textFieldStyles.textInput, {height}]}
+        />
+        {value !== '' && (
+          <TouchableOpacity onPress={clearInput}>
+            <Icon name="XCircle" color={theme.palette.gray3} />
+          </TouchableOpacity>
+        )}
+      </View>
+      <View style={textFieldStyles.currentBalanceContainer}>
+        <Typography type={'Body2Regular'}>현재 대차 : </Typography>
+        <TouchableOpacity>
+          <Typography
+            type={'Body2Regular'}
+            onPress={handlePressCurrentBalanceButton}
+            style={textFieldStyles.currentBalanceText}>
+            {`${calculateCurrentBalance()}원`}
+          </Typography>
         </TouchableOpacity>
-      )}
-    </View>
+      </View>
+    </>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
+const textFieldStyles = StyleSheet.create({
+  textFieldContainer: {
     flexDirection: 'row',
-    borderBottomWidth: 1,
+    borderBottomWidth: 1.5,
     borderBottomColor: theme.palette.primary,
     justifyContent: 'space-between',
     gap: 10,
@@ -96,11 +141,19 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     width: '100%',
     flex: 1,
+    marginBottom: 10,
   },
   textInput: {
     ...theme.typography.Title1Bold,
     placeholderTextColor: theme.palette.gray3,
     maxWidth: '93%',
     flex: 1,
+  },
+  currentBalanceContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+  },
+  currentBalanceText: {
+    borderBottomWidth: 1,
   },
 });

--- a/src/components/@common/TextField/index.tsx
+++ b/src/components/@common/TextField/index.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 import {
   NativeSyntheticEvent,
   StyleSheet,
@@ -63,27 +63,22 @@ export default function TextField({
   };
 
   const calculateCurrentBalance = () => {
+    return (
+      -parseNumberFromString(defaultCurrentBalance!) +
+      Number(parseNumberFromString(value))
+    );
+  };
+
+  const getCurrentBalance = () => {
     const currentBalance = formatNumberToLocaleString(
-      String(
-        -parseNumberFromString(defaultCurrentBalance!) +
-          Number(parseNumberFromString(value)),
-      ),
+      String(calculateCurrentBalance()),
     );
 
     return currentBalance;
   };
 
   const handlePressCurrentBalanceButton = () => {
-    setValue(
-      formatValue(
-        String(
-          -(
-            -parseNumberFromString(defaultCurrentBalance!) +
-            Number(parseNumberFromString(value))
-          ),
-        ),
-      ),
-    );
+    setValue(formatValue(String(-calculateCurrentBalance())));
   };
 
   return (
@@ -121,7 +116,7 @@ export default function TextField({
             type={'Body2Regular'}
             onPress={handlePressCurrentBalanceButton}
             style={textFieldStyles.currentBalanceText}>
-            {`${calculateCurrentBalance()}원`}
+            {`${getCurrentBalance()}원`}
           </Typography>
         </TouchableOpacity>
       </View>

--- a/src/components/@common/TextField/index.tsx
+++ b/src/components/@common/TextField/index.tsx
@@ -1,31 +1,26 @@
-import Icon from 'components/@common/Icon';
 import React, {useState} from 'react';
 import {
   NativeSyntheticEvent,
   StyleSheet,
   TextInput,
   TextInputContentSizeChangeEventData,
+  TextInputKeyPressEventData,
   TextInputProps,
   TouchableOpacity,
   View,
 } from 'react-native';
 import {theme} from 'styles';
+import {
+  formatNumberToLocaleString,
+  formatValue,
+  parseNumberFromString,
+} from 'utils/formatValue';
+import Icon from 'components/@common/Icon';
 
-/**
- * @param value 텍스트 필드에 표시될 값
- * @param onChangeText 값이 변경될 때 호출. 변경된 텍스트가 매개변수로 전달
- * @param ...props - react native TextInputProps
- */
-type TextFieldProps = {
-  value: string;
-  onChangeText: (text: string) => void;
-} & Omit<TextInputProps, 'value' | 'onChangeText'>;
+type TextFieldProps = TextInputProps;
 
-export default function TextField({
-  value,
-  onChangeText,
-  ...props
-}: TextFieldProps) {
+export default function TextField({defaultValue, ...props}: TextFieldProps) {
+  const [value, setValue] = useState(formatValue(defaultValue) ?? '');
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const [height, setHeight] = useState(0);
 
@@ -33,8 +28,7 @@ export default function TextField({
   const handleBlur = () => setIsFocused(false);
 
   const clearInput = () => {
-    onChangeText('');
-    setHeight(0);
+    setValue(`0원`);
   };
 
   const handleInputHeight = (
@@ -42,6 +36,24 @@ export default function TextField({
   ) => {
     e.nativeEvent.contentSize.height &&
       setHeight(e.nativeEvent.contentSize.height);
+  };
+
+  const onChangeText = (text: string) => setValue(formatValue(text));
+
+  const handleKeyPress = (
+    e: NativeSyntheticEvent<TextInputKeyPressEventData>,
+  ) => {
+    if (e.nativeEvent.key === 'Backspace') {
+      if (value !== '0원') {
+        const parsedValue = parseNumberFromString(value).slice(0, -1);
+
+        setValue(`${formatNumberToLocaleString(parsedValue)}원`);
+      } else {
+        setValue(`0원`);
+      }
+
+      e.preventDefault();
+    }
   };
 
   return (
@@ -59,6 +71,7 @@ export default function TextField({
         placeholder={props.placeholder ?? '내용을 입력해주세요.'}
         onFocus={handleFocus}
         onBlur={handleBlur}
+        onKeyPress={handleKeyPress}
         multiline={true}
         underlineColorAndroid="transparent"
         onContentSizeChange={handleInputHeight}
@@ -87,7 +100,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   textInput: {
-    ...theme.typography.Title2Regular,
+    ...theme.typography.Title1Bold,
     placeholderTextColor: theme.palette.gray3,
     maxWidth: '93%',
     flex: 1,

--- a/src/components/@common/TextField/index.tsx
+++ b/src/components/@common/TextField/index.tsx
@@ -133,7 +133,7 @@ const textFieldStyles = StyleSheet.create({
     gap: 10,
     alignItems: 'center',
     paddingVertical: 11,
-    paddingHorizontal: 16,
+    paddingRight: 16,
     width: '100%',
     flex: 1,
     marginBottom: 10,

--- a/src/components/@common/TextFields/AmountTextField/AmountTextField.stories.tsx
+++ b/src/components/@common/TextFields/AmountTextField/AmountTextField.stories.tsx
@@ -1,0 +1,18 @@
+import {ComponentStory} from '@storybook/react';
+import AmountTextField from 'components/@common/TextFields/AmountTextField';
+
+const meta = {
+  title: 'components/AmountTextField',
+  component: AmountTextField,
+};
+
+export default meta;
+
+type Story = ComponentStory<typeof AmountTextField>;
+
+const Template: Story = args => <AmountTextField {...args} />;
+
+export const DefaultStatus = Template.bind({});
+DefaultStatus.args = {
+  defaultCurrentBalance: '-8500000',
+};

--- a/src/components/@common/TextFields/AmountTextField/index.tsx
+++ b/src/components/@common/TextFields/AmountTextField/index.tsx
@@ -23,7 +23,7 @@ import Typography from 'components/@common/Typography';
  */
 type TextFieldProps = {defaultCurrentBalance?: string} & TextInputProps;
 
-export default function TextField({
+export default function AmountTextField({
   defaultValue,
   defaultCurrentBalance,
   ...props
@@ -33,10 +33,12 @@ export default function TextField({
   const [height, setHeight] = useState(0);
 
   const handleFocus = () => setIsFocused(true);
+
   const handleBlur = () => setIsFocused(false);
 
   const clearInput = () => {
     setValue(`0원`);
+    setHeight(0);
   };
 
   const handleInputHeight = (

--- a/src/components/@common/TextFields/AmountTextField/index.tsx
+++ b/src/components/@common/TextFields/AmountTextField/index.tsx
@@ -1,22 +1,17 @@
 import React, {useState} from 'react';
 import {
   NativeSyntheticEvent,
-  StyleSheet,
-  TextInput,
   TextInputContentSizeChangeEventData,
   TextInputKeyPressEventData,
   TextInputProps,
-  TouchableOpacity,
-  View,
 } from 'react-native';
-import {theme} from 'styles';
 import {
   formatNumberToLocaleString,
   formatValue,
   parseNumberFromString,
 } from 'utils/formatValue';
-import Icon from 'components/@common/Icon';
-import Typography from 'components/@common/Typography';
+import CommonTextField from 'components/@common/TextFields/CommonTextField';
+import DescriptionText from 'components/@common/TextFields/DescriptionText';
 
 /**
  * @param defaultCurrentBalance 현재 대차를 나타내는 텍스트
@@ -26,7 +21,6 @@ type TextFieldProps = {defaultCurrentBalance?: string} & TextInputProps;
 export default function AmountTextField({
   defaultValue,
   defaultCurrentBalance,
-  ...props
 }: TextFieldProps) {
   const [value, setValue] = useState(formatValue(defaultValue) ?? '');
   const [isFocused, setIsFocused] = useState<boolean>(false);
@@ -36,8 +30,8 @@ export default function AmountTextField({
 
   const handleBlur = () => setIsFocused(false);
 
-  const clearInput = () => {
-    setValue(`0원`);
+  const handleClearInput = () => {
+    setValue('0원');
     setHeight(0);
   };
 
@@ -64,93 +58,24 @@ export default function AmountTextField({
     }
   };
 
-  const calculateCurrentBalance = () => {
-    return (
-      -parseNumberFromString(defaultCurrentBalance!) +
-      Number(parseNumberFromString(value))
-    );
-  };
-
-  const getCurrentBalance = () => {
-    const currentBalance = formatNumberToLocaleString(
-      String(calculateCurrentBalance()),
-    );
-
-    return currentBalance;
-  };
-
-  const handlePressCurrentBalanceButton = () => {
-    setValue(formatValue(String(-calculateCurrentBalance())));
-  };
-
   return (
     <>
-      <View
-        style={[
-          textFieldStyles.textFieldContainer,
-          {
-            borderBottomColor:
-              theme.palette[isFocused || value ? 'primary' : 'gray3'],
-          },
-        ]}>
-        <TextInput
-          value={value}
-          onChangeText={onChangeText}
-          placeholder={props.placeholder ?? '내용을 입력해주세요.'}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
-          onKeyPress={handleKeyPress}
-          multiline={true}
-          underlineColorAndroid="transparent"
-          onContentSizeChange={handleInputHeight}
-          style={[textFieldStyles.textInput, {height}]}
-        />
-        {value !== '' && (
-          <TouchableOpacity onPress={clearInput}>
-            <Icon name="XCircle" color={theme.palette.gray3} />
-          </TouchableOpacity>
-        )}
-      </View>
-      <View style={textFieldStyles.currentBalanceContainer}>
-        <Typography type={'Body2Regular'}>현재 대차 : </Typography>
-        <TouchableOpacity>
-          <Typography
-            type={'Body2Regular'}
-            onPress={handlePressCurrentBalanceButton}
-            style={textFieldStyles.currentBalanceText}>
-            {`${getCurrentBalance()}원`}
-          </Typography>
-        </TouchableOpacity>
-      </View>
+      <CommonTextField
+        value={value}
+        isFocused={isFocused}
+        height={height}
+        onChangeText={onChangeText}
+        handleBlur={handleBlur}
+        handleFocus={handleFocus}
+        handleInputHeight={handleInputHeight}
+        handleClearInput={handleClearInput}
+        handleKeyPress={handleKeyPress}
+      />
+      <DescriptionText
+        value={value}
+        setValue={setValue}
+        defaultCurrentBalance={defaultCurrentBalance}
+      />
     </>
   );
 }
-
-const textFieldStyles = StyleSheet.create({
-  textFieldContainer: {
-    flexDirection: 'row',
-    borderBottomWidth: 1.5,
-    borderBottomColor: theme.palette.primary,
-    justifyContent: 'space-between',
-    gap: 10,
-    alignItems: 'center',
-    paddingVertical: 11,
-    paddingRight: 16,
-    width: '100%',
-    flex: 1,
-    marginBottom: 10,
-  },
-  textInput: {
-    ...theme.typography.Title1Bold,
-    placeholderTextColor: theme.palette.gray3,
-    maxWidth: '93%',
-    flex: 1,
-  },
-  currentBalanceContainer: {
-    display: 'flex',
-    flexDirection: 'row',
-  },
-  currentBalanceText: {
-    borderBottomWidth: 1,
-  },
-});

--- a/src/components/@common/TextFields/AmountTextField/index.tsx
+++ b/src/components/@common/TextFields/AmountTextField/index.tsx
@@ -61,6 +61,7 @@ export default function AmountTextField({
   return (
     <>
       <CommonTextField
+        isAmountField={true}
         value={value}
         isFocused={isFocused}
         height={height}

--- a/src/components/@common/TextFields/CommonTextField.tsx
+++ b/src/components/@common/TextFields/CommonTextField.tsx
@@ -1,0 +1,90 @@
+import {
+  View,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  TextInputProps,
+  NativeSyntheticEvent,
+  TextInputKeyPressEventData,
+  TextInputContentSizeChangeEventData,
+} from 'react-native';
+import {theme} from 'styles';
+import Icon from 'components/@common/Icon';
+
+type CommonTextFieldProps = TextInputProps & {
+  isFocused: boolean;
+  height: number;
+  handleBlur: () => void;
+  handleFocus: () => void;
+  handleInputHeight: (
+    e: NativeSyntheticEvent<TextInputContentSizeChangeEventData>,
+  ) => void;
+  handleClearInput: () => void;
+  handleKeyPress?: (
+    e: NativeSyntheticEvent<TextInputKeyPressEventData>,
+  ) => void;
+};
+
+export default function CommonTextField({
+  isFocused,
+  value,
+  height,
+  onChangeText,
+  handleBlur,
+  handleFocus,
+  handleInputHeight,
+  handleClearInput,
+  handleKeyPress,
+  ...props
+}: CommonTextFieldProps) {
+  return (
+    <View
+      style={[
+        commonTextFieldStyles.textFieldContainer,
+        {
+          borderBottomColor:
+            theme.palette[isFocused || value ? 'primary' : 'gray3'],
+        },
+      ]}>
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={props.placeholder ?? '내용을 입력해주세요.'}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onKeyPress={e => handleKeyPress?.(e)}
+        multiline={true}
+        underlineColorAndroid="transparent"
+        onContentSizeChange={handleInputHeight}
+        style={[commonTextFieldStyles.textInput, {height}]}
+      />
+      {value !== '' && (
+        <TouchableOpacity onPress={handleClearInput}>
+          <Icon name="XCircle" color={theme.palette.gray3} />
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+const commonTextFieldStyles = StyleSheet.create({
+  textFieldContainer: {
+    flexDirection: 'row',
+    borderBottomWidth: 1.5,
+    borderBottomColor: theme.palette.primary,
+    justifyContent: 'space-between',
+    gap: 10,
+    alignItems: 'center',
+    paddingVertical: 11,
+    paddingRight: 16,
+    width: '100%',
+    flex: 1,
+    marginBottom: 10,
+  },
+  textInput: {
+    ...theme.typography.Title1Bold,
+    placeholderTextColor: theme.palette.gray3,
+    maxWidth: '93%',
+    flex: 1,
+  },
+});

--- a/src/components/@common/TextFields/CommonTextField.tsx
+++ b/src/components/@common/TextFields/CommonTextField.tsx
@@ -12,6 +12,7 @@ import {theme} from 'styles';
 import Icon from 'components/@common/Icon';
 
 type CommonTextFieldProps = TextInputProps & {
+  isAmountField?: boolean;
   isFocused: boolean;
   height: number;
   handleBlur: () => void;
@@ -26,6 +27,7 @@ type CommonTextFieldProps = TextInputProps & {
 };
 
 export default function CommonTextField({
+  isAmountField = false,
   isFocused,
   value,
   height,
@@ -56,6 +58,7 @@ export default function CommonTextField({
         multiline={true}
         underlineColorAndroid="transparent"
         onContentSizeChange={handleInputHeight}
+        keyboardType={isAmountField ? 'phone-pad' : 'default'}
         style={[commonTextFieldStyles.textInput, {height}]}
       />
       {value !== '' && (

--- a/src/components/@common/TextFields/DescriptionText.tsx
+++ b/src/components/@common/TextFields/DescriptionText.tsx
@@ -1,0 +1,63 @@
+import {Dispatch, SetStateAction} from 'react';
+import {View, TouchableOpacity, StyleSheet} from 'react-native';
+import {
+  formatNumberToLocaleString,
+  formatValue,
+  parseNumberFromString,
+} from 'utils/formatValue';
+import Typography from 'components/@common/Typography';
+
+type DescriptionTextProps = {
+  value: string;
+  setValue: Dispatch<SetStateAction<string>>;
+  defaultCurrentBalance?: string;
+};
+
+export default function DescriptionText({
+  value,
+  setValue,
+  defaultCurrentBalance,
+}: DescriptionTextProps) {
+  const calculateCurrentBalance = () => {
+    return (
+      -parseNumberFromString(defaultCurrentBalance!) +
+      Number(parseNumberFromString(value))
+    );
+  };
+
+  const getCurrentBalance = () => {
+    const currentBalance = formatNumberToLocaleString(
+      String(calculateCurrentBalance()),
+    );
+
+    return currentBalance;
+  };
+
+  const handlePressCurrentBalanceButton = () => {
+    setValue(formatValue(String(-calculateCurrentBalance())));
+  };
+
+  return (
+    <View style={textFieldStyles.currentBalanceContainer}>
+      <Typography type={'Body2Regular'}>현재 대차 : </Typography>
+      <TouchableOpacity>
+        <Typography
+          type={'Body2Regular'}
+          onPress={handlePressCurrentBalanceButton}
+          style={textFieldStyles.currentBalanceText}>
+          {`${getCurrentBalance()}원`}
+        </Typography>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const textFieldStyles = StyleSheet.create({
+  currentBalanceContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+  },
+  currentBalanceText: {
+    borderBottomWidth: 1,
+  },
+});

--- a/src/components/@common/TextFields/DescriptionText.tsx
+++ b/src/components/@common/TextFields/DescriptionText.tsx
@@ -38,13 +38,13 @@ export default function DescriptionText({
   };
 
   return (
-    <View style={textFieldStyles.currentBalanceContainer}>
+    <View style={descriptionTextStyles.currentBalanceContainer}>
       <Typography type={'Body2Regular'}>현재 대차 : </Typography>
       <TouchableOpacity>
         <Typography
           type={'Body2Regular'}
           onPress={handlePressCurrentBalanceButton}
-          style={textFieldStyles.currentBalanceText}>
+          style={descriptionTextStyles.currentBalanceText}>
           {`${getCurrentBalance()}원`}
         </Typography>
       </TouchableOpacity>
@@ -52,7 +52,7 @@ export default function DescriptionText({
   );
 }
 
-const textFieldStyles = StyleSheet.create({
+const descriptionTextStyles = StyleSheet.create({
   currentBalanceContainer: {
     display: 'flex',
     flexDirection: 'row',

--- a/src/components/@common/TextFields/TextField/TextField.stories.tsx
+++ b/src/components/@common/TextFields/TextField/TextField.stories.tsx
@@ -1,5 +1,5 @@
 import {ComponentStory} from '@storybook/react';
-import TextField from 'components/@common/TextField';
+import TextField from 'components/@common/TextFields/TextField';
 
 const meta = {
   title: 'components/TextField',
@@ -13,6 +13,4 @@ type Story = ComponentStory<typeof TextField>;
 const Template: Story = args => <TextField {...args} />;
 
 export const DefaultStatus = Template.bind({});
-DefaultStatus.args = {
-  defaultCurrentBalance: '-8500000',
-};
+DefaultStatus.args = {};

--- a/src/components/@common/TextFields/TextField/index.tsx
+++ b/src/components/@common/TextFields/TextField/index.tsx
@@ -1,26 +1,21 @@
 import {useState} from 'react';
 import {
-  View,
-  TextInput,
-  TouchableOpacity,
-  StyleSheet,
   TextInputProps,
   NativeSyntheticEvent,
   TextInputContentSizeChangeEventData,
 } from 'react-native';
-import {theme} from 'styles';
-import Icon from 'components/@common/Icon';
+import CommonTextField from 'components/@common/TextFields/CommonTextField';
 
 type TextFieldProps = TextInputProps;
 
-export default function TextField({defaultValue, ...props}: TextFieldProps) {
+export default function TextField({defaultValue}: TextFieldProps) {
   const [value, setValue] = useState(defaultValue ?? '');
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const [height, setHeight] = useState(0);
 
   const onChangeText = (text: string) => setValue(text);
 
-  const clearInput = () => {
+  const handleClearInput = () => {
     setValue('');
     setHeight(0);
   };
@@ -37,52 +32,15 @@ export default function TextField({defaultValue, ...props}: TextFieldProps) {
   };
 
   return (
-    <View
-      style={[
-        textFieldStyles.textFieldContainer,
-        {
-          borderBottomColor:
-            theme.palette[isFocused || value ? 'primary' : 'gray3'],
-        },
-      ]}>
-      <TextInput
-        value={value}
-        onChangeText={onChangeText}
-        placeholder={props.placeholder ?? '내용을 입력해주세요.'}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-        multiline={true}
-        underlineColorAndroid="transparent"
-        onContentSizeChange={handleInputHeight}
-        style={[textFieldStyles.textInput, {height}]}
-      />
-      {value !== '' && (
-        <TouchableOpacity onPress={clearInput}>
-          <Icon name="XCircle" color={theme.palette.gray3} />
-        </TouchableOpacity>
-      )}
-    </View>
+    <CommonTextField
+      value={value}
+      isFocused={isFocused}
+      height={height}
+      onChangeText={onChangeText}
+      handleBlur={handleBlur}
+      handleFocus={handleFocus}
+      handleInputHeight={handleInputHeight}
+      handleClearInput={handleClearInput}
+    />
   );
 }
-
-const textFieldStyles = StyleSheet.create({
-  textFieldContainer: {
-    flexDirection: 'row',
-    borderBottomWidth: 1.5,
-    borderBottomColor: theme.palette.primary,
-    justifyContent: 'space-between',
-    gap: 10,
-    alignItems: 'center',
-    paddingVertical: 11,
-    paddingRight: 16,
-    width: '100%',
-    flex: 1,
-    marginBottom: 10,
-  },
-  textInput: {
-    ...theme.typography.Title1Bold,
-    placeholderTextColor: theme.palette.gray3,
-    maxWidth: '93%',
-    flex: 1,
-  },
-});

--- a/src/components/@common/TextFields/TextField/index.tsx
+++ b/src/components/@common/TextFields/TextField/index.tsx
@@ -1,0 +1,88 @@
+import {useState} from 'react';
+import {
+  View,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  TextInputProps,
+  NativeSyntheticEvent,
+  TextInputContentSizeChangeEventData,
+} from 'react-native';
+import {theme} from 'styles';
+import Icon from 'components/@common/Icon';
+
+type TextFieldProps = TextInputProps;
+
+export default function TextField({defaultValue, ...props}: TextFieldProps) {
+  const [value, setValue] = useState(defaultValue ?? '');
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+  const [height, setHeight] = useState(0);
+
+  const onChangeText = (text: string) => setValue(text);
+
+  const clearInput = () => {
+    setValue('');
+    setHeight(0);
+  };
+
+  const handleFocus = () => setIsFocused(true);
+
+  const handleBlur = () => setIsFocused(false);
+
+  const handleInputHeight = (
+    e: NativeSyntheticEvent<TextInputContentSizeChangeEventData>,
+  ) => {
+    e.nativeEvent.contentSize.height &&
+      setHeight(e.nativeEvent.contentSize.height);
+  };
+
+  return (
+    <View
+      style={[
+        textFieldStyles.textFieldContainer,
+        {
+          borderBottomColor:
+            theme.palette[isFocused || value ? 'primary' : 'gray3'],
+        },
+      ]}>
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={props.placeholder ?? '내용을 입력해주세요.'}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        multiline={true}
+        underlineColorAndroid="transparent"
+        onContentSizeChange={handleInputHeight}
+        style={[textFieldStyles.textInput, {height}]}
+      />
+      {value !== '' && (
+        <TouchableOpacity onPress={clearInput}>
+          <Icon name="XCircle" color={theme.palette.gray3} />
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+const textFieldStyles = StyleSheet.create({
+  textFieldContainer: {
+    flexDirection: 'row',
+    borderBottomWidth: 1.5,
+    borderBottomColor: theme.palette.primary,
+    justifyContent: 'space-between',
+    gap: 10,
+    alignItems: 'center',
+    paddingVertical: 11,
+    paddingRight: 16,
+    width: '100%',
+    flex: 1,
+    marginBottom: 10,
+  },
+  textInput: {
+    ...theme.typography.Title1Bold,
+    placeholderTextColor: theme.palette.gray3,
+    maxWidth: '93%',
+    flex: 1,
+  },
+});

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -3,17 +3,20 @@ import {StyleSheet} from 'react-native';
 export const typographyStyles = StyleSheet.create({
   /** Title1_m - size: 24, weight: 700 */
   Title1Bold: {
+    fontFamily: 'Pretendard-Bold',
     fontSize: 24,
     fontWeight: '700',
   },
   /** Title1 - size: 24, weight: 600, letter-spacing:-1.2 */
   Title1Semibold1: {
+    fontFamily: 'Pretendard-SemiBold',
     fontSize: 24,
     fontWeight: '600',
     letterSpacing: -1.2,
   },
   /** Title1_m: size: 20, weight: 600, line-height: 150%(36px) */
   Title1Semibold2: {
+    fontFamily: 'Pretendard-SemiBold',
     fontSize: 24,
     fontWeight: '600',
     lineHeight: 36,
@@ -21,34 +24,40 @@ export const typographyStyles = StyleSheet.create({
 
   /** Title2 - size: 16, weight: 700 */
   Title2Bold: {
+    fontFamily: 'Pretendard-Bold',
     fontWeight: '700',
     fontSize: 20,
     lineHeight: 36,
   },
   /** Title2_l - size: 16, weight: 400 */
   Title2Regular: {
+    fontFamily: 'Pretendard-Regular',
     fontWeight: '400',
     fontSize: 16,
   },
 
   /** size: 16, weight: 600 */
   Body1Semibold: {
+    fontFamily: 'Pretendard-SemiBold',
     fontWeight: '600',
     fontSize: 16,
   },
   /** size: 16, weight: 400 */
   Body1Regular: {
+    fontFamily: 'Pretendard-Regular',
     fontWeight: '400',
     fontSize: 16,
   },
 
   /** size: 13, weight: 600 */
   Body2Semibold: {
+    fontFamily: 'Pretendard-SemiBold',
     fontWeight: '600',
     fontSize: 13,
   },
   /** size: 13, weight: 400 */
   Body2Regular: {
+    fontFamily: 'Pretendard-Regular',
     fontWeight: '400',
     fontSize: 13,
   },

--- a/src/utils/formatValue.ts
+++ b/src/utils/formatValue.ts
@@ -1,0 +1,17 @@
+export const formatNumberToLocaleString = (value: string): string => {
+  return Number(value).toLocaleString();
+};
+
+export const parseNumberFromString = (value: string) => {
+  return value.replace(/[^0-9]/g, '');
+};
+
+export const formatValue = (value?: string): string => {
+  if (!value) return '0원';
+
+  const formattedValue = formatNumberToLocaleString(
+    parseNumberFromString(value),
+  );
+
+  return `${formattedValue}원`;
+};


### PR DESCRIPTION
## Describe your changes
<!-- 스크린샷 및 작업 내용을 적어주세요 -->
기본 텍스트 필드와 금액 관련 텍스트 필드로 구분해서 작업해놨습니다.
기본 텍스트 필드는 별다른 기능 없이 단순 텍스트만 관리하는 용도이고, 금액 관련 텍스트 필드는 아래 기능들을 추가해놨습니다.
1. 금액 관련 로직 처리
2. 현재 대차 관련 계산 로직 처리 (현재 대차 부분 밑줄 친 금액 클릭 시 그에 맞는 value 값을 계산해서 나타내도록 했습니다.)

![image](https://github.com/Central-MakeUs/Easybud-Client/assets/81316050/4fe13536-cf33-418f-8286-fbda7be1a9ca)
![image](https://github.com/Central-MakeUs/Easybud-Client/assets/81316050/7ffd31a3-f19f-4a5b-9da8-8f5a090bfac6)

그리고 AmountTextField를 사용하는 경우 keyboardType을 'phone-pad'로 설정해주도록 변경해놨습니다.

![image](https://github.com/Central-MakeUs/Easybud-Client/assets/81316050/68dc86fe-fc6d-44b5-90a0-740f1fec8d05)

아래는 default keyboardType입니다.

![image](https://github.com/Central-MakeUs/Easybud-Client/assets/81316050/2e17c78c-1ea4-47b6-81ca-7afe9ac86578)


## To Reviewers
<!-- 리뷰어에게 남기는 참고 사항을 적어주세요 -->
