### PR TITLE
[TAS-157] 빈 스크린 보이는 문제 해결

### DIFF
--- a/src/navigators/components/NullScreen.tsx
+++ b/src/navigators/components/NullScreen.tsx
@@ -1,3 +1,15 @@
-const NullScreen = () => null;
+import {useFocusEffect, useNavigation} from '@react-navigation/native';
+
+const NullScreen = () => {
+  const navigation = useNavigation();
+
+  useFocusEffect(() => {
+    navigation.navigate('CreateTransactionStack', {
+      screen: 'BasicTransactionInfo',
+    });
+  });
+
+  return null;
+};
 
 export default NullScreen;


### PR DESCRIPTION
## Describe your changes
<!-- 스크린샷 및 작업 내용을 적어주세요 -->
현재 탭 내비게이터에는 장부, 거래, 널 스크린 이렇게 세 탭이 있습니다.
가운데 위치한 + 버튼 주변을 클릭하면 널 스크린으로 이동됩니다.
그래서 사용자 입장에서 빈 페이지를 볼 가능성이 있어, 해당 널 스크린으로 접속 시 바로 거래 추가 탭으로 이동시키도록 로직 추가해뒀습니다.

## To Reviewers
<!-- 리뷰어에게 남기는 참고 사항을 적어주세요 -->
